### PR TITLE
Feature: Header Template Part

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -10,6 +10,9 @@ namespace Create_WordPress_Theme;
 define( 'CREATE_WORDPRESS_THEME_PATH', __DIR__ );
 define( 'CREATE_WORDPRESS_THEME_URL', get_template_directory_uri() );
 
+// Block customizations.
+require_once CREATE_WORDPRESS_THEME_PATH . '/inc/blocks.php';
+
 // Theme setup.
 require_once CREATE_WORDPRESS_THEME_PATH . '/inc/theme.php';
 

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Manage Gutenberg-related logic.
+ *
+ * @package Create_WordPress_Theme
+ */
+
+namespace Create_WordPress_Theme\Blocks;
+
+add_filter( 'render_block_core/template-part', __NAMESPACE__ . '\remove_core_template_part_wrapper', 10, 2 );
+
+/**
+ * Filters the content of a 'core/template-part' block.
+ *
+ * @param string $block_content The block content.
+ * @param array  $block         The full block, including name and attributes.
+ * @return string
+ */
+function remove_core_template_part_wrapper( $block_content, $block ) {
+	$skip_wrapper = $block['attrs']['skipWrapper'] ?? false;
+
+	/*
+	 * Allow passing "skipWrapper": true with template part block to remove the
+	 * the wrapper automatically added by core. This is useful to avoid extra
+	 * wrappers, as template part blocks do not currently support an `ID`
+	 * attribute. This also allows the block to more closely mimic the
+	 * `get_template_part()` function.
+	 */
+	if ( true === $skip_wrapper ) {
+		$proc = new \WP_HTML_Tag_Processor( $block_content );
+
+		if ( true === $proc->next_tag() ) {
+			$block_content = trim( $block_content );
+
+			// Remove opening tag.
+			$block_content = substr(
+				$block_content,
+				strpos( $block_content, '>' ) + 1
+			);
+
+			// Remove closing tag.
+			$block_content = substr(
+				$block_content,
+				0,
+				strlen( $block_content ) - strlen( "</{$proc->get_tag()}>" ),
+			);
+
+			$block_content = trim( $block_content );
+		}
+	}
+
+	return $block_content;
+}

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Manage Gutenberg-related logic.
+ * Manage block-related logic.
  *
  * @package Create_WordPress_Theme
  */

--- a/parts/header.html
+++ b/parts/header.html
@@ -3,10 +3,11 @@ wp:group {
     "className": "site-header",
     "layout": {
         "type": "constrained"
-    }
+    },
+    "tagName": "header"
 }
 -->
-<div id="masthead" class="wp-block-group site-header">
+<header id="masthead" class="wp-block-group site-header">
     <!--
     wp:group {
         "className": "site-header__inner",
@@ -45,5 +46,5 @@ wp:group {
         <!-- /wp:buttons -->
     </div>
     <!-- /wp:group -->
-</div>
+</header>
 <!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,0 +1,49 @@
+<!--
+wp:group {
+    "className": "site-header",
+    "layout": {
+        "type": "constrained"
+    }
+}
+-->
+<div id="masthead" class="wp-block-group site-header">
+    <!--
+    wp:group {
+        "className": "site-header__inner",
+        "layout": {
+            "type": "flex",
+            "flexWrap": "nowrap"
+        }
+    }
+    -->
+    <div class="wp-block-group site-header__inner">
+        <!-- wp:site-logo /-->
+
+        <!-- create-wordpress-plugin:theme-navigation {"menuLocation": "header"} -->
+
+        <!--
+        wp:buttons {
+            "layout": {
+                "type": "flex",
+                "justifyContent": "right"
+            },
+            "style": {
+                "layout": {
+                    "selfStretch": "fill",
+                    "flexSize": null
+                }
+            }
+        }
+        -->
+        <div class="wp-block-buttons">
+            <!-- wp:button -->
+            <div class="wp-block-button">
+                <a class="wp-block-button__link wp-element-button" href="?s=">Search</a>
+            </div>
+            <!-- /wp:button -->
+        </div>
+        <!-- /wp:buttons -->
+    </div>
+    <!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/style.css
+++ b/style.css
@@ -1,0 +1,14 @@
+/*
+Theme Name: create-wordpress-theme
+Theme URI: https://alley.com/
+Author: Alley
+Author URI: https://alley.com/
+Description: esc_description( 'Get going' )
+Version: 1.0
+Requires at least: 6.4
+Tested up to: 6.4
+Requires PHP: 8.2
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: create-wordpress-theme
+*/

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,6 @@
+<!--
+wp:template-part {
+	"slug": "header",
+	"tagName": "header"
+}
+/-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 <!--
 wp:template-part {
 	"slug": "header",
-	"tagName": "header"
+	"skipWrapper": true
 }
 /-->

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "settings": {
+    "layout": {
+      "contentSize": "48rem",
+      "wideSize": "80rem"
+    }
+  },
+  "styles": {},
+  "customTemplates": {},
+  "templateParts": [
+    {
+      "name": "header",
+      "title": "Header",
+      "area": "header"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #5 

- Adds the header template part.
- Adds `skipWrapper` functionality to allow template parts to render without a wrapper. This is useful to avoid extra markup (for example, the core template part block doesn't support an `ID` attribute, so an extra group block would be needed within or around the template part to accomplish that). It's also useful for template parts like the global header and footer that may contain opening and closing elements meant to wrap the entire page.
- Adds a basic theme.json file.

**To do: Accessibility Considerations**
- The header will typically include an `<h1>` on the homepage only, and likely only be visible by screen readers. This can be accomplished using a combination of a conditional block and the core site title block (or heading block) with the `screen-reader-text` class.
- A "skip to content" link should be added at the top of the page when the content area is built out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced block customizations for enhanced content management.
  - New site header layout with logo, navigation, and search functionality.

- **Documentation**
  - Updated theme metadata with new version requirements and licensing details.

- **Refactor**
  - Implemented a cleaner header template integration to streamline the theme structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->