### PR TITLE
Feature: Single Post Template

### DIFF
--- a/inc/theme.php
+++ b/inc/theme.php
@@ -14,10 +14,16 @@ add_action( 'admin_menu', __NAMESPACE__ . '\action__admin_menu' );
  * Setup theme defaults and registers support for various WordPress features.
  */
 function action__after_setup_theme(): void {
-	/**
-	 * Add menu support.
-	 */
+	// Add menu support.
 	add_theme_support( 'menus' );
+
+	// Register navigation menu locations.
+	register_nav_menus(
+		[
+			'header' => __( 'Header', 'create-wordpress-theme' ),
+			'footer' => __( 'Footer', 'create-wordpress-theme' ),
+		]
+	);
 }
 
 /**

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,0 +1,119 @@
+<!--
+wp:template-part {
+	"slug": "header",
+	"skipWrapper": true
+}
+/-->
+
+<!--
+wp:group {
+	"tagName": "main",
+	"className": "site-main",
+	"layout": {
+		"type": "default"
+	}
+}
+-->
+<main id="main" class="wp-block-group site-main">
+	<!--
+	wp:group {
+		"tagName": "article",
+		"layout": {
+			"type": "default"
+		}
+	}
+	-->
+	<article class="wp-block-group">
+		<!--
+		wp:group {
+			"tagName": "header",
+			"className": "entry-header",
+			"layout": {
+				"type": "constrained"
+			}
+		}
+		-->
+		<header class="wp-block-group entry-header">
+			<!-- wp:post-featured-image {"align":"wide"} /-->
+
+			<!-- 
+				@todo Replace with Primary Category.
+				@see https://github.com/alleyinteractive/create-wordpress-project/issues/53
+			-->
+			<!-- wp:post-terms {"term":"category"} /-->
+
+			<!--
+			wp:post-title {
+				"level": 1,
+				"className": "entry-title"
+			}
+			/-->
+
+			<!-- 
+				@todo Replace with Subheadline.
+				@see https://github.com/alleyinteractive/create-wordpress-project/issues/52
+			-->
+			<!-- wp:post-excerpt /-->
+
+			<!--
+			wp:group {
+				"layout": {
+					"type": "flex",
+					"flexWrap": "wrap",
+					"justifyContent": "left"
+				}
+			}
+			-->
+			<div class="wp-block-group">
+				
+				<!-- 
+					@todo Replace with Byline.
+					@see https://github.com/alleyinteractive/byline-manager/issues/74
+				-->
+				<!-- wp:post-author-name {"isLink":true} /-->
+
+				<!-- wp:post-date /-->
+
+			</div>
+			<!-- /wp:group -->
+
+			<!-- wp:post-terms {"term":"post_tag"} /-->
+		</header>
+		<!-- /wp:group -->
+
+		<!--
+		wp:post-content {
+			"className": "entry-content",
+			"layout": {
+				"type": "constrained"
+			}
+		}
+		/-->
+
+		<!--
+		wp:group {
+			"tagName": "aside",
+			"className": "entry-aside",
+			"layout": {
+				"type": "constrained"
+			}
+		}
+		-->
+		<aside class="wp-block-group entry-aside">
+			<!-- 
+				@todo Related Content.
+				@see https://github.com/alleyinteractive/create-wordpress-project/issues/54
+			-->
+		</aside>
+		<!-- /wp:group -->
+	</article>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!--
+wp:template-part {
+	"slug": "footer",
+	"skipWrapper": true
+}
+/-->


### PR DESCRIPTION
Related issue: #9 
- Scaffolds out the initial single post template, with some core block fallbacks and comments in areas where custom blocks are not yet complete.
- Registers the `header` and `footer` menu locations, used within the header & footer template parts.