### PR TITLE
Add block names to common groups in templates

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -12,8 +12,8 @@ wp:group {
 	"layout": {
 		"type": "default"
 	},
-	"metadata":{
-		"name":"Site Main"
+	"metadata": {
+		"name": "Site Main"
 	}
 }
 -->
@@ -24,8 +24,8 @@ wp:group {
 		"layout": {
 			"type": "default"
 		},
-		"metadata":{
-			"name":"Article"
+		"metadata": {
+			"name": "Article"
 		}
 	}
 	-->
@@ -37,15 +37,15 @@ wp:group {
 			"layout": {
 				"type": "constrained"
 			},
-			"metadata":{
-				"name":"Entry Header"
+			"metadata": {
+				"name": "Entry Header"
 			}
 		}
 		-->
 		<header class="wp-block-group entry-header">
 			<!--
 			wp:heading {
-				"level":1,
+				"level": 1,
 				"className": "entry-title",
 			}
 			-->
@@ -56,12 +56,12 @@ wp:group {
 
 		<!--
 		wp:group {
-			"className":"entry-content",
-			"layout":{
-				"type":"constrained"
+			"className": "entry-content",
+			"layout": {
+				"type": "constrained"
 			},
-			"metadata":{
-				"name":"Entry Content"
+			"metadata": {
+				"name": "Entry Content"
 			}
 		}
 		-->

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -12,8 +12,8 @@ wp:group {
 	"layout": {
 		"type": "default"
 	},
-	"metadata":{
-		"name":"Site Main"
+	"metadata": {
+		"name": "Site Main"
 	}
 }
 -->

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -11,6 +11,9 @@ wp:group {
 	"className": "site-main",
 	"layout": {
 		"type": "default"
+	},
+	"metadata":{
+		"name":"Site Main"
 	}
 }
 -->
@@ -21,7 +24,7 @@ wp:group {
 		"className": "screen-reader-text"
 	}
 	/-->
-	
+
 	<!--
 	wp:post-content {
 		"layout": {

--- a/templates/page.html
+++ b/templates/page.html
@@ -11,6 +11,9 @@ wp:group {
 	"className": "site-main",
 	"layout": {
 		"type": "default"
+	},
+	"metadata":{
+		"name":"Site Main"
 	}
 }
 -->
@@ -20,6 +23,9 @@ wp:group {
 		"tagName": "article",
 		"layout": {
 			"type": "default"
+		},
+		"metadata":{
+			"name":"Article"
 		}
 	}
 	-->
@@ -30,6 +36,9 @@ wp:group {
 			"className": "entry-header",
 			"layout": {
 				"type": "constrained"
+			},
+			"metadata":{
+				"name":"Entry Header"
 			}
 		}
 		-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -12,8 +12,8 @@ wp:group {
 	"layout": {
 		"type": "default"
 	},
-	"metadata":{
-		"name":"Site Main"
+	"metadata": {
+		"name": "Site Main"
 	}
 }
 -->
@@ -24,8 +24,8 @@ wp:group {
 		"layout": {
 			"type": "default"
 		},
-		"metadata":{
-			"name":"Article"
+		"metadata": {
+			"name": "Article"
 		}
 	}
 	-->
@@ -37,8 +37,8 @@ wp:group {
 			"layout": {
 				"type": "constrained"
 			},
-			"metadata":{
-				"name":"Entry Header"
+			"metadata": {
+				"name": "Entry Header"
 			}
 		}
 		-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -11,6 +11,9 @@ wp:group {
 	"className": "site-main",
 	"layout": {
 		"type": "default"
+	},
+	"metadata":{
+		"name":"Site Main"
 	}
 }
 -->
@@ -20,6 +23,9 @@ wp:group {
 		"tagName": "article",
 		"layout": {
 			"type": "default"
+		},
+		"metadata":{
+			"name":"Article"
 		}
 	}
 	-->
@@ -30,13 +36,16 @@ wp:group {
 			"className": "entry-header",
 			"layout": {
 				"type": "constrained"
+			},
+			"metadata":{
+				"name":"Entry Header"
 			}
 		}
 		-->
 		<header class="wp-block-group entry-header">
 			<!-- wp:post-featured-image {"align":"wide"} /-->
 
-			<!-- 
+			<!--
 				@todo Replace with Primary Category.
 				@see https://github.com/alleyinteractive/create-wordpress-project/issues/53
 			-->
@@ -49,7 +58,7 @@ wp:group {
 			}
 			/-->
 
-			<!-- 
+			<!--
 				@todo Replace with Subheadline.
 				@see https://github.com/alleyinteractive/create-wordpress-project/issues/52
 			-->
@@ -61,12 +70,15 @@ wp:group {
 					"type": "flex",
 					"flexWrap": "wrap",
 					"justifyContent": "left"
+				},
+				"metadata":{
+					"name":"Entry Header Meta"
 				}
 			}
 			-->
 			<div class="wp-block-group">
-				
-				<!-- 
+
+				<!--
 					@todo Replace with Byline.
 					@see https://github.com/alleyinteractive/byline-manager/issues/74
 				-->
@@ -96,11 +108,14 @@ wp:group {
 			"className": "entry-aside",
 			"layout": {
 				"type": "constrained"
+			},
+			"metadata":{
+				"name":"Entry Aside"
 			}
 		}
 		-->
 		<aside class="wp-block-group entry-aside">
-			<!-- 
+			<!--
 				@todo Related Content.
 				@see https://github.com/alleyinteractive/create-wordpress-project/issues/54
 			-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -12,8 +12,8 @@ wp:group {
 	"layout": {
 		"type": "default"
 	},
-	"metadata":{
-		"name":"Site Main"
+	"metadata": {
+		"name": "Site Main"
 	}
 }
 -->
@@ -24,8 +24,8 @@ wp:group {
 		"layout": {
 			"type": "default"
 		},
-		"metadata":{
-			"name":"Article"
+		"metadata": {
+			"name": "Article"
 		}
 	}
 	-->
@@ -37,8 +37,8 @@ wp:group {
 			"layout": {
 				"type": "constrained"
 			},
-			"metadata":{
-				"name":"Entry Header"
+			"metadata": {
+				"name": "Entry Header"
 			}
 		}
 		-->
@@ -71,8 +71,8 @@ wp:group {
 					"flexWrap": "wrap",
 					"justifyContent": "left"
 				},
-				"metadata":{
-					"name":"Entry Header Meta"
+				"metadata": {
+					"name": "Entry Header Meta"
 				}
 			}
 			-->
@@ -109,8 +109,8 @@ wp:group {
 			"layout": {
 				"type": "constrained"
 			},
-			"metadata":{
-				"name":"Entry Aside"
+			"metadata": {
+				"name": "Entry Aside"
 			}
 		}
 		-->


### PR DESCRIPTION
Provides some additional context for group blocks when scanning List View in site editor
![image](https://github.com/alleyinteractive/create-wordpress-theme/assets/370019/e8e71a99-21d0-4a11-9281-be92d1191414)
