### PR TITLE
adding basic composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "alleyinteractive/create-wordpress-theme",
+  "description": "A skeleton WordPress theme",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "alleyinteractive",
+    "create-wordpress-theme"
+  ],
+  "authors": [
+    {
+      "name": "Alley",
+      "email": "info@alley.com"
+    }
+  ],
+  "homepage": "https://github.com/alleyinteractive/create-wordpress-theme",
+  "require": {
+    "php": "^8.2"
+  }
+}


### PR DESCRIPTION
In order to be able to run `composer create-project alleyinteractive/create-wordpress-theme themes/<theme-slug>`, `create-wordpress-theme` must be in packagist. In order to be listed on packagist, we need a composer.json file.