### PR TITLE
PHPStan & PHPCS Fixes

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -13,6 +13,8 @@ add_filter( 'render_block_core/post-featured-image', __NAMESPACE__ . '\render_co
 /**
  * Filters the content of a 'core/template-part' block.
  *
+ * @phpstan-param array{attrs: array<string, mixed>} $block
+ *
  * @param string $block_content The block content.
  * @param array  $block         The full block, including name and attributes.
  * @return string
@@ -56,6 +58,8 @@ function remove_core_template_part_wrapper( $block_content, $block ) {
 /**
  * Filters the content of the 'core/post-featured-image' block.
  *
+ * @phpstan-param array{attrs: array<string, mixed>} $block
+ *
  * @param string $block_content The block content.
  * @param array  $block         The full block, including name and attributes.
  * @return string
@@ -66,7 +70,7 @@ function render_core_post_featured_image( $block_content, $block ) {
 	/*
 	 * Allow passing "ariaHidden": true with post featured image block to remove
 	 * the tab stop and hide the image from screen readers.
-	 * 
+	 *
 	 * This is useful when linked within archive listings or card components,
 	 * since the post title serves as the post link.
 	 */

--- a/inc/site-editor.php
+++ b/inc/site-editor.php
@@ -18,7 +18,7 @@ function action__admin_menu(): void {
 	if ( ! in_array( wp_get_environment_type(), [ 'local', 'development' ], true ) ) {
 		remove_submenu_page( 'themes.php', 'site-editor.php' );
 
-		if ( $pagenow === 'site-editor.php' ) {
+		if ( 'site-editor.php' === $pagenow ) {
 			wp_safe_redirect( admin_url() );
 			exit;
 		}

--- a/inc/theme.php
+++ b/inc/theme.php
@@ -32,9 +32,13 @@ function action__after_setup_theme(): void {
  * @return void
  */
 function action__admin_menu(): void {
+	if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+		return;
+	}
+
 	// Build the customize.php URL.
 	$current_url   = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
-	$customize_url = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), $current_url ) ), 'customize.php' );
+	$customize_url = add_query_arg( 'return', rawurlencode( remove_query_arg( wp_removable_query_args(), $current_url ) ), 'customize.php' );
 
 	add_submenu_page(
 		'themes.php',


### PR DESCRIPTION
## Summary
While working on [TECH-111](https://l.alley.dev/08d4bfa65c) identified some adjustments that could be made to the theme that will help PHPStan and PHPCS to pass (out of the box) after configuring a new project with Create WordPress Project.

[TECH-111]: https://alleyinteractive.atlassian.net/browse/TECH-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ