### PR TITLE
Issue-43: Add Skip Link

### DIFF
--- a/assets/scss/_a11y.scss
+++ b/assets/scss/_a11y.scss
@@ -1,0 +1,42 @@
+@use '@/assets/scss/layout';
+
+/**
+ * Visually hide an element and leave it only for screenreaders
+ */
+@mixin screen-reader-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+/**
+ * Sets initial styles for the 'Skip to content' link; hidden until it has focus.
+ */
+@mixin skip-link {
+  @include layout.auto-margins;
+  background-color: #fff;
+  color: inherit;
+  left: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: rem(10);
+  position: absolute;
+  right: 0;
+  text-align: center;
+  text-decoration: none;
+  top: 0;
+  transform: translateY(-100%);
+  width: max-content;
+  z-index: -1;
+
+  &:focus {
+    opacity: 1;
+    transform: translateY(0);
+    z-index: 2147483647; // Theoretical max.
+  }
+}

--- a/assets/scss/_layout.scss
+++ b/assets/scss/_layout.scss
@@ -1,0 +1,9 @@
+// Layout-related mixins go here.
+
+/**
+ * Centered block.
+ */
+@mixin auto-margins {
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/entries/global/index.scss
+++ b/entries/global/index.scss
@@ -19,3 +19,12 @@ global entry styles.
 */
 
 @use '@/assets/scss/normalize' as *;
+@use '@/assets/scss/a11y';
+
+.screen-reader-text {
+  @include a11y.screen-reader-only;
+}
+
+.skip-link {
+  @include a11y.skip-link;
+}

--- a/entries/global/index.scss
+++ b/entries/global/index.scss
@@ -18,8 +18,8 @@ global entry styles.
 
 */
 
-@use '@/assets/scss/normalize' as *;
 @use '@/assets/scss/a11y';
+@use '@/assets/scss/normalize' as *;
 
 .screen-reader-text {
   @include a11y.screen-reader-only;

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,3 +1,4 @@
+<a class="skip-link screen-reader-text" href="#main">Skip to Content</a>
 <!--
 wp:group {
 	"className": "site-header",


### PR DESCRIPTION
### Summary

Fixes #43

This pull request introduces a "Skip to Content" accessibility feature to enhance keyboard and screen reader navigation:

- Adds an accessible "Skip to Content" link at the very top of the page, allowing users to quickly jump to the main content area.
- Implements new SCSS partials for accessibility (`_a11y.scss`) and layout (`_layout.scss`) in the `assets/scss/` directory.
  - `_a11y.scss` includes a `screen-reader-only` mixin to visually hide content while keeping it accessible to assistive technologies, and a `skip-link` mixin to style skip navigation links for visibility when focused.
  - `_layout.scss` introduces an `auto-margins` mixin for horizontally centering elements.
- Adds utility classes:
  - `.screen-reader-text` (for visually hidden, screen reader-accessible content)
  - `.skip-link` (for styling the skip link)
- The skip link is hidden visually but becomes visible when focused, ensuring accessibility for keyboard users.

### Testing Instructions

- Navigate to the site.
- Use the keyboard (Tab key) to focus on the "Skip to Content" link.
- Verify that the link is visible when focused and allows skipping to the main content.
- Ensure the link is accessible to screen readers.

### Checklist

- [ ] I have tested these changes locally.
- [ ] I have updated documentation as needed.
- [ ] I have added necessary unit/integration tests.
- [ ] The code style follows the project's guidelines.