### PR TITLE
Fix block style versioning

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -52,23 +52,28 @@ function enqueue_block_styles() {
 			return;
 		}
 
-		$css_files = array_filter(
+		$block_directories = array_filter(
 			$folder_contents,
-			function ( $item ) {
-				return pathinfo( $item, PATHINFO_EXTENSION ) === 'css';
+			function ( $item ) use ( $folder ) {
+				return is_dir( $folder . '/' . $item ) && ! in_array( $item, [ '.', '..' ], true );
 			}
 		);
 
-		// Create entry details.
-		foreach ( $css_files as $css_file ) {
-			$block_name      = preg_replace( '/\.css$/', '', $css_file );
-			$block_entries[] = [
-				'block_name'      => $block_name,
-				'block_namespace' => $dir . '/' . $block_name,
-				'file_name'       => $css_file,
-				'file_path'       => $folder . '/',
-				'handle'          => get_template() . '-' . $dir . '-' . $block_name,
-			];
+		// Create entry details for each block directory.
+		foreach ( $block_directories as $block_dir ) {
+			$block_folder   = $folder . '/' . $block_dir;
+			$index_css_path = $block_folder . '/index.css';
+
+			// Check if index.css exists in the block directory.
+			if ( file_exists( $index_css_path ) ) {
+				$block_entries[] = [
+					'block_name'      => $block_dir,
+					'block_namespace' => $dir . '/' . $block_dir,
+					'file_name'       => 'index.css',
+					'file_path'       => $block_folder,
+					'handle'          => get_template() . '-' . $dir . '-' . $block_dir,
+				];
+			}
 		}
 	}
 
@@ -78,13 +83,15 @@ function enqueue_block_styles() {
 	}
 
 	foreach ( $block_entries as $block ) {
+		$entry_dir = 'block-styles/' . $block['block_namespace'];
+
 		wp_enqueue_block_style(
 			$block['block_namespace'],
 			[
 				'handle' => $block['handle'] . '-styles', // Ex: `create-wordpress-theme-core-paragraph-styles`.
-				'src'    => get_template_directory_uri() . '/build/block-styles/' . $block['block_namespace'] . '.css',
-				'deps'   => get_asset_dependency_array( $block['block_namespace'] ),
-				'ver'    => get_asset_version( $block['block_namespace'] ),
+				'src'    => get_template_directory_uri() . '/build/' . trailingslashit( $entry_dir ) . $block['file_name'],
+				'deps'   => get_asset_dependency_array( $entry_dir ),
+				'ver'    => get_asset_version( $entry_dir ),
 
 				// Adding "path" allows inlining of block styles on the frontend when possible.
 				'path'   => $block['file_path'] . '/' . $block['file_name'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ const config = {
 
       return {
         ...acc,
-        [`block-styles/${namespace}/${entryName}`]: entry,
+        [`block-styles/${namespace}/${entryName}/index`]: entry,
       };
     }, {});
 


### PR DESCRIPTION
Updates the build system to create directories for each block style. This is better aligned with the handling of other entries and allows our asset version helpers to remain the same.

**Before:**
* build/block-styles/core/image.scss
* build/block-styles/core/image.asset.php

**After:**
* build/block-styles/core/image/index.scss
* build/block-styles/core/image/index.asset.php

Fixes #46 